### PR TITLE
[feat] Jungjuhyeon

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,13 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.17.7'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/entity/BaseEntity.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package kr.co.ureca.Jungjuhyeon.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    public LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    public LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/BusinessException.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/BusinessException.java
@@ -1,0 +1,11 @@
+package kr.co.ureca.Jungjuhyeon.global.exception;
+
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class BusinessException extends RuntimeException{
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/errorcode/CommonErrorCode.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/errorcode/CommonErrorCode.java
@@ -1,0 +1,30 @@
+package kr.co.ureca.Jungjuhyeon.global.exception.errorcode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode{
+    // 공용 처리
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "4000", "Invalid parameter included"),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "4040", "Resource not exists"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5000", "알수없는 에러 관리자에게 문의"),
+
+
+    //좌석 4100
+    SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "4101", "해당 좌석을 찾을 수 없습니다."),
+    SEAT_ALREADY_RESERVED(HttpStatus.CONFLICT, "4102", "해당 좌석은 이미 예약되었습니다."),
+    SEAT_CANNOT_BE_RESERVED(HttpStatus.CONFLICT, "4103", "이미 예약한 좌석이 있습니다."),
+
+    //유저 4200
+    USER_ID_PASSWORD_FOUND(HttpStatus.BAD_REQUEST, "4201", "아이디 또는 비밀번호가 잘못되었습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "4202", "해당하는 유저가 없습니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/errorcode/ErrorCode.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/errorcode/ErrorCode.java
@@ -1,0 +1,9 @@
+package kr.co.ureca.Jungjuhyeon.global.exception.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,97 @@
+package kr.co.ureca.Jungjuhyeon.global.exception.handler;
+
+
+import kr.co.ureca.Jungjuhyeon.global.exception.BusinessException;
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.CommonErrorCode;
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.ErrorCode;
+import kr.co.ureca.Jungjuhyeon.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.BadRequestException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleQuizException(final BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Object> handleIllegalArgument(final IllegalArgumentException e) {
+        log.warn("handleIllegalArgument", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<Object> handleIllegalArgument(final BadRequestException e) {
+        log.warn("handleBadRequest", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(errorCode, e.getMessage());
+    }
+
+    @Override
+    @Nullable
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            final MethodArgumentNotValidException e,
+            final HttpHeaders headers,
+            final HttpStatusCode statusCode,
+            final WebRequest request) {
+        log.warn("handleIllegalArgument", e);
+        final ErrorCode errorCode = CommonErrorCode.INVALID_PARAMETER;
+        return handleExceptionInternal(e, errorCode);
+    }
+
+    @ExceptionHandler({Exception.class})
+    public ResponseEntity<Object> handleAllException(final Exception ex) {
+        log.warn("handleAllException", ex);
+        final ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(final ErrorCode errorCode) {
+        return ErrorResponse.of(errorCode);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final ErrorCode errorCode, final String message) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(errorCode, message));
+    }
+
+    private ErrorResponse makeErrorResponse(final ErrorCode errorCode, final String message) {
+        return ErrorResponse.of(errorCode, message);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(final BindException e, final ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(makeErrorResponse(e, errorCode));
+    }
+
+    private ErrorResponse makeErrorResponse(final BindException e, final ErrorCode errorCode) {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.ValidationError::of)
+                .forEach(ve -> errorResponse.getErrors().add(ve));
+
+        return errorResponse;
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/ApiResponse.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/ApiResponse.java
@@ -1,0 +1,16 @@
+package kr.co.ureca.Jungjuhyeon.global.response;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ApiResponse {
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public ApiResponse(Boolean isSuccess, String code, String message) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/ErrorResponse.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/ErrorResponse.java
@@ -1,0 +1,60 @@
+package kr.co.ureca.Jungjuhyeon.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ErrorResponse extends ApiResponse{
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors = new ArrayList<>();
+
+    private ErrorResponse(ErrorCode errorCode){
+        super(false, errorCode.getCode(), errorCode.getMessage());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode){
+        return new ErrorResponse(errorCode);
+    }
+
+    private ErrorResponse(ErrorCode errorCode, String message){
+        super(false, errorCode.getCode(), message);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message){
+        return new ErrorResponse(errorCode, message);
+    }
+
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "{\n" +
+                "    \"isSuccess\":" + super.getIsSuccess() + ",\n" +
+                "    \"code\":\"" + super.getCode() + "\",\n" +
+                "    \"message\":\"" + super.getMessage() + "\"\n" +
+                "}";
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/SuccessResponse.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/global/response/SuccessResponse.java
@@ -1,0 +1,24 @@
+package kr.co.ureca.Jungjuhyeon.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+
+@Getter
+public class SuccessResponse<T> extends ApiResponse{
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final T result;
+
+    private SuccessResponse(T data){
+        super(true, "200", "OK");
+        this.result = data;
+    }
+
+    public static <T> SuccessResponse<T> success(T data){
+        return new SuccessResponse<>(data);
+    }
+    public static <T> SuccessResponse<T> successWithoutResult(T data){
+        return new SuccessResponse<>(null);
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/redis/RedisConfig.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/redis/RedisConfig.java
@@ -1,0 +1,51 @@
+package kr.co.ureca.Jungjuhyeon.redis;
+
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 일반적인 key:value 의 경우 시리얼라이저
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    //redsson 설정 분산락
+    @Bean
+    public RedissonClient redissonClient(){
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        return Redisson.create(config);
+    }
+}
+

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/seat/application/SeatService.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/seat/application/SeatService.java
@@ -1,0 +1,117 @@
+package kr.co.ureca.Jungjuhyeon.seat.application;
+
+import kr.co.ureca.Jungjuhyeon.global.exception.BusinessException;
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.CommonErrorCode;
+import kr.co.ureca.Jungjuhyeon.user.domin.Enum.ReservationStatus;
+import kr.co.ureca.Jungjuhyeon.seat.domain.Seat;
+import kr.co.ureca.Jungjuhyeon.seat.presentation.dto.SeatDto;
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import kr.co.ureca.Jungjuhyeon.seat.infrastructure.SeatJpaRepository;
+import kr.co.ureca.Jungjuhyeon.user.infrastructure.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class SeatService {
+
+    private final SeatJpaRepository seatJpaRepository;
+    private final UserJpaRepository userJpaRepository;
+    private final RedissonClient redissonClient;
+//    @Transactional(isolation = Isolation.SERIALIZABLE)
+    @Transactional
+    public SeatDto.Response.reservationDto reservation(Long seatNo, User user) {
+        // Redis 분산 락 생성
+        RLock lock = redissonClient.getLock("seat-reservation-lock-" + seatNo);
+
+        try {
+            // 락 획득 시도, 대기 시간 100ms, 락 만료 시간 1초
+            boolean available = lock.tryLock(100, 2000, TimeUnit.MILLISECONDS);
+            log.info("Attempting to acquire lock: " + available);
+
+
+            if (!available) {
+                log.info("Lock acquisition failed, seat already reserved");
+                // 락을 얻지 못한 경우, 이미 예매된 것으로 처리
+                throw new BusinessException(CommonErrorCode.SEAT_ALREADY_RESERVED);
+
+            }
+
+            // 좌석 찾기
+            Seat findseat = seatJpaRepository.findBySeatNo(seatNo)
+                    .orElseThrow(() -> new BusinessException(CommonErrorCode.SEAT_NOT_FOUND));
+
+            log.info("Seat status before update: " );
+
+            // 만약 이미 좌석이 예약되었는지 다시 한번 확인
+            if (findseat.getUser() != null) {
+                log.info("Seat already reserved");
+                throw new BusinessException(CommonErrorCode.SEAT_ALREADY_RESERVED);
+            }
+
+            // user 영속화
+            User persistentUser = userJpaRepository.findById(user.getId())
+                    .orElseThrow(() -> new BusinessException(CommonErrorCode.USER_NOT_FOUND));
+
+            findseat.allocateUser(persistentUser);
+            // 좌석을 예약 상태로 변경
+            seatJpaRepository.flush();  // 명시적으로 flush
+
+            log.info("Reservation successful");
+
+            // 예약 정보 반환
+            return SeatDto.Response.reservationDto.of(user.getId(), findseat.getSeatNo());
+
+        } catch (InterruptedException e) {
+            // 락 획득 과정에서 인터럽트가 발생한 경우 예외 처리
+            throw new BusinessException(CommonErrorCode.SEAT_ALREADY_RESERVED);
+        } finally {
+            // 락 해제
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+                log.info("Lock released");
+
+            }
+        }
+    }
+
+    @Transactional
+    public void delete(SeatDto.Request.deleteDto request) {
+        User user = userJpaRepository.findByNickName(request.getNickName()).orElseThrow(()-> new BusinessException(CommonErrorCode.USER_NOT_FOUND));
+        //  비밀번호가 일치한지
+        if(!user.checkPassword(request.getPassword())){
+            throw new BusinessException(CommonErrorCode.USER_ID_PASSWORD_FOUND);
+        }
+        Seat seat = user.getSeat();
+        seat.deleteSeat(user);
+    }
+
+
+
+    public List<SeatDto.Response.SeatListDto> searchSeatList() {
+        return seatJpaRepository.findSeatEntityGraph().stream()
+                .map(seat -> {
+                    User user = seat.getUser();
+                    if (user != null) {
+                        return SeatDto.Response.SeatListDto.of(seat.getSeatNo(), user.getStatus(), user.getNickName(), user.getName());
+                    } else {
+                        return SeatDto.Response.SeatListDto.of(seat.getSeatNo(), ReservationStatus.NOT_RESERVED, null, null); // 혹은 원하는 기본값으로 처리
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+}
+
+

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/seat/domain/Seat.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/seat/domain/Seat.java
@@ -1,0 +1,38 @@
+package kr.co.ureca.Jungjuhyeon.seat.domain;
+
+
+import jakarta.persistence.*;
+import kr.co.ureca.Jungjuhyeon.user.domin.Enum.ReservationStatus;
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import lombok.*;
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Seat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="seat_id")
+    private Long id;
+
+    private Long seatNo;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    //== 자리 할당 메소드 ==//
+    public void allocateUser(User user) {
+        this.user = user;
+        user.allocateSeat(this); // 양방향 관계 설정
+    }
+
+    //== 의자 삭제 메소드 ==//
+    public void deleteSeat(User user){
+        this.user = null;
+        user.deleteSeat(this);
+    }
+
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/seat/infrastructure/SeatJpaRepository.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/seat/infrastructure/SeatJpaRepository.java
@@ -1,0 +1,20 @@
+package kr.co.ureca.Jungjuhyeon.seat.infrastructure;
+
+import kr.co.ureca.Jungjuhyeon.seat.domain.Seat;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public interface SeatJpaRepository extends JpaRepository<Seat,Long> {
+    Optional<Seat> findBySeatNo(Long seatNo);
+
+    //EntityGraph+jpql
+    @EntityGraph(attributePaths = {"user"})
+    @Query("select s from Seat s")
+    List<Seat> findSeatEntityGraph();
+}
+

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/seat/presentation/SeatController.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/seat/presentation/SeatController.java
@@ -1,0 +1,40 @@
+package kr.co.ureca.Jungjuhyeon.seat.presentation;
+
+import jakarta.validation.Valid;
+import kr.co.ureca.Jungjuhyeon.global.response.SuccessResponse;
+import kr.co.ureca.Jungjuhyeon.seat.application.SeatService;
+import kr.co.ureca.Jungjuhyeon.user.application.UserService;
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import kr.co.ureca.Jungjuhyeon.seat.presentation.dto.SeatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ureca")
+public class SeatController {
+
+    private final SeatService seatService;
+    private final UserService userService;
+
+    @PatchMapping("/reservation")
+    public SuccessResponse<SeatDto.Response.reservationDto> reservation(@RequestBody @Valid SeatDto.Request.reservationDto reuqest){
+        User user = userService.login(reuqest);
+        SeatDto.Response.reservationDto response = seatService.reservation(reuqest.getSeatNo(),user);
+        return SuccessResponse.success(response);
+    }
+
+    @PatchMapping("/delete")
+    public SuccessResponse<String> delete(@RequestBody @Valid SeatDto.Request.deleteDto request){
+        seatService.delete(request);
+        return SuccessResponse.successWithoutResult("성공");
+    }
+
+    @GetMapping()
+    private SuccessResponse<List<SeatDto.Response.SeatListDto>> searchSeatList(){
+        List<SeatDto.Response.SeatListDto> response = seatService.searchSeatList();
+        return  SuccessResponse.success(response);
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/seat/presentation/dto/SeatDto.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/seat/presentation/dto/SeatDto.java
@@ -1,0 +1,86 @@
+package kr.co.ureca.Jungjuhyeon.seat.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import kr.co.ureca.Jungjuhyeon.user.domin.Enum.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+public class SeatDto {
+
+    public static class Request {
+        @Getter
+        @Builder
+        public static class reservationDto {
+            @NotBlank
+            private String userName;
+            @NotBlank
+            private String nickName;
+            @NotBlank
+            private String password;
+            @NotNull
+            private Long seatNo;
+
+            public static Request.reservationDto of(String userName,String nickName,String password,Long seatNo) {
+                return reservationDto.builder()
+                        .userName(userName)
+                        .nickName(nickName)
+                        .password(password)
+                        .seatNo(seatNo)
+                        .build();
+            }
+        }
+
+        @Getter
+        @Builder
+        public static class deleteDto {
+            @NotBlank
+            private String nickName;
+            @NotBlank
+            private String password;
+
+            public static Request.deleteDto of(String nickName, String password){
+                return deleteDto.builder()
+                        .nickName(nickName)
+                        .password(password)
+                        .build();
+            }
+
+        }
+    }
+    public static class Response {
+        @Builder
+        @Getter
+        public static class reservationDto {
+            private Long userId;
+            private Long seatNo;
+
+            public static reservationDto of(Long userId, Long seatId) {
+                return reservationDto.builder()
+                        .userId(userId)
+                        .seatNo(seatId)
+                        .build();
+            }
+        }
+        @Builder
+        @Getter
+        public static class SeatListDto {
+            private Long seatNo;
+            private ReservationStatus status;
+            private String nickName;
+            private String userName;
+
+            public static SeatListDto of(Long seatNo,ReservationStatus status,String nickName,String userName){
+                return SeatListDto.builder()
+                        .seatNo(seatNo)
+                        .status(status)
+                        .nickName(nickName)
+                        .userName(userName)
+                        .build();
+            }
+
+        }
+
+    }
+
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/user/application/UserService.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/user/application/UserService.java
@@ -1,0 +1,49 @@
+package kr.co.ureca.Jungjuhyeon.user.application;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import kr.co.ureca.Jungjuhyeon.global.exception.BusinessException;
+import kr.co.ureca.Jungjuhyeon.global.exception.errorcode.CommonErrorCode;
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import kr.co.ureca.Jungjuhyeon.user.infrastructure.UserJpaRepository;
+import kr.co.ureca.Jungjuhyeon.seat.presentation.dto.SeatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserJpaRepository userJpaRepository;
+    @PersistenceContext
+    EntityManager em;
+
+     // 여기서 새로운 트랜잭션을 시작하여 forceJoin 메서드가 실행됨
+     @Transactional
+     public User login(SeatDto.Request.reservationDto request){
+        User user = userJpaRepository.findByNickName(request.getNickName()).orElseGet(() -> forceJoin(request));
+
+//        비밀번호가 일치한지
+        if(!user.checkPassword(request.getPassword())){
+            throw new BusinessException(CommonErrorCode.USER_ID_PASSWORD_FOUND);
+        }
+//        이미 예약한 좌석이 있는지
+        if(user.getSeat() !=null){
+            throw new BusinessException(CommonErrorCode.SEAT_CANNOT_BE_RESERVED);
+        }
+
+        return user;
+    }
+
+//    존재하지 않을시 생성
+    public User forceJoin(SeatDto.Request.reservationDto request) {
+        User newUser = User.create(request.getNickName(),request.getUserName(),request.getPassword());
+        return userJpaRepository.save(newUser);
+    }
+
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/Enum/ReservationStatus.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/Enum/ReservationStatus.java
@@ -1,0 +1,5 @@
+package kr.co.ureca.Jungjuhyeon.user.domin.Enum;
+
+public enum ReservationStatus {
+    RESERVED, NOT_RESERVED
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/User.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/User.java
@@ -1,0 +1,59 @@
+package kr.co.ureca.Jungjuhyeon.user.domin;
+
+import jakarta.persistence.*;
+import kr.co.ureca.Jungjuhyeon.user.domin.Enum.ReservationStatus;
+import kr.co.ureca.Jungjuhyeon.seat.domain.Seat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name ="user_id")
+    private Long id;
+
+    @Column(unique = true)
+    private String nickName;
+
+    private String name;
+
+    private String password;
+
+    @OneToOne(mappedBy = "user")
+    private Seat seat;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+    //== 생성 메소드 ==//
+    public static User create(String nickName, String name,String password){
+        return User.builder()
+                .nickName(nickName)
+                .name(name)
+                .password(password)
+                .status(ReservationStatus.NOT_RESERVED)
+                .build();
+    }
+    //== 의자 할당 메소드 ==//
+    public void allocateSeat(Seat seat){
+        this.seat =seat;
+        this.status = ReservationStatus.RESERVED;
+    }
+    //== 의자 삭제 메소드 ==//
+    public void deleteSeat(Seat seat){
+        this.seat = null;
+        this.status = ReservationStatus.NOT_RESERVED;
+    }
+
+    //== 비밀번호 일치 확인 메소드 ==//
+    public boolean checkPassword(String password){
+        return this.password.equals(password);
+    }
+}

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/User.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/user/domin/User.java
@@ -27,7 +27,7 @@ public class User {
 
     private String password;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(fetch = FetchType.LAZY,mappedBy = "user")
     private Seat seat;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/kr/co/ureca/Jungjuhyeon/user/infrastructure/UserJpaRepository.java
+++ b/src/main/java/kr/co/ureca/Jungjuhyeon/user/infrastructure/UserJpaRepository.java
@@ -1,0 +1,10 @@
+package kr.co.ureca.Jungjuhyeon.user.infrastructure;
+
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserJpaRepository extends JpaRepository<User,Long> {
+    Optional<User> findByNickName(String name);
+}

--- a/src/test/java/kr/co/ureca/SeatServiceTest.java
+++ b/src/test/java/kr/co/ureca/SeatServiceTest.java
@@ -1,0 +1,85 @@
+package kr.co.ureca;
+
+import kr.co.ureca.Jungjuhyeon.global.exception.BusinessException;
+import kr.co.ureca.Jungjuhyeon.seat.application.SeatService;
+import kr.co.ureca.Jungjuhyeon.user.domin.Enum.ReservationStatus;
+import kr.co.ureca.Jungjuhyeon.seat.domain.Seat;
+import kr.co.ureca.Jungjuhyeon.seat.infrastructure.SeatJpaRepository;
+import kr.co.ureca.Jungjuhyeon.seat.presentation.dto.SeatDto;
+import kr.co.ureca.Jungjuhyeon.user.application.UserService;
+import kr.co.ureca.Jungjuhyeon.user.domin.User;
+import kr.co.ureca.Jungjuhyeon.user.infrastructure.UserJpaRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest
+@Transactional
+//@Rollback(value = false)
+public class SeatServiceTest {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private SeatService seatService;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+
+    @Autowired
+    private SeatJpaRepository seatJpaRepository;
+
+    private final Long seatNo = 9L; // 테스트할 좌석 번호
+
+    @Test
+    public void testConcurrentSeatReservation() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            String email = "user" + i + "@example.com";
+            String password = "password" + i;
+
+            int finalI = i;
+            executorService.submit(() -> {
+                try {
+                    SeatDto.Request.reservationDto request = SeatDto.Request.reservationDto.of("user" + finalI, email, password, seatNo);
+                    User user = userService.login(request);
+                    seatService.reservation(seatNo, user);
+                } catch (BusinessException e) {
+                    System.out.println("User " + finalI + " failed to reserve the seat: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await(10, TimeUnit.SECONDS); // 시간 여유를 두어 충분히 대기
+
+        Seat reservedSeat = seatJpaRepository.findBySeatNo(seatNo).orElseThrow();
+        // 예약된 좌석의 상태를 확인
+        assertThat(reservedSeat.getUser().getStatus()).isEqualTo(ReservationStatus.RESERVED);
+
+
+        long reservedCount = userJpaRepository.findAll().stream()
+                .filter(user -> user.getSeat() != null && user.getSeat().getSeatNo().equals(seatNo))
+                .count();
+
+        // 오직 한 명만이 좌석을 예약해야 함
+        assertThat(reservedCount).isEqualTo(1);
+    }
+
+}
+
+
+


### PR DESCRIPTION
## 이슈

[의자 예약 기능에서 동시성 문제 발생]
- 동시에 많은 사람들이 동일한 좌석을 예약하려 시도할 경우, 잘못된 상태로 저장되는 문제가 발생함.
- redis 락을 사용한 동시성 처리

[유저와 좌석의 연관관계 수정]
- 좌석에 유저 객체를 외래키로 가지게끔 설정함 -> 좌석을 조회할 시, 유저에대한 정보가 필요함.  

## 구현 기능

- Redis 분산 락을 사용한 좌석 예약 동시성 문제 해결.
- 좌석 예약 시 User와 Seat의 연관관계 관리 로직 추가.

## 상세 설명

 [좌석 예약 기능 (SeatService.reservation)]

- Redis의 RLock을 활용하여 좌석 번호를 기반으로 락을 생성.
- 예약 시, 좌석이 이미 예약된 상태인지 검증한 후 예약 가능 여부에 따라 상태를 업데이트.

[변경된 연관관계 관리]
- User와 Seat 간의 일관된 상태를 유지하기 위해, allocateSeat()와 deleteSeat() 메소드 수정.
- Seat에서 User를 설정하면 동시에 User도 해당 Seat에 대한 참조를 가지도록 로직 보완.

